### PR TITLE
認証失敗時にバックエンドへリダイレクトするように変更 / バックエンドとのOidc 連携

### DIFF
--- a/src/features/myenglish/MyEnglishAPI.js
+++ b/src/features/myenglish/MyEnglishAPI.js
@@ -3,11 +3,22 @@ import axios from 'axios';
 const requestQuestionTitleBaseUrl =  'http://localhost:8080/quizrest';
 const requestQuestionDetailsBaseUrl = "http://localhost:8080/quizdetailsrest";
 const requestTakeQuestionBaseUrl = "http://localhost:8080/takequizrest/";
+const authLoginUrl = "http://localhost:8080/login"
+axios.defaults.withCredentials = true;
+
+
+function redirectBackendServer(error){
+    console.log(error);
+    console.log(error.response);
+    window.location.href = authLoginUrl;
+    console.log(error)
+}
 
 export const questionTitleSave = async (questionTitle) => {
     try{
         return await axios.post(requestQuestionTitleBaseUrl+'/save', questionTitle);
     }catch (error){
+        redirectBackendServer(error);
         throw error;
     }
 }
@@ -16,6 +27,7 @@ export const questionTitleUpdate = async (newQuestionTitle) => {
     try{
         return await axios.post(requestQuestionTitleBaseUrl+'/update', newQuestionTitle);
     }catch (error){
+        redirectBackendServer(error);
         throw error;
     }
 }
@@ -25,6 +37,7 @@ export const questionTitleGet = async ()=> {
         const response = await axios.get(requestQuestionTitleBaseUrl)
         return response.data;
     }catch (error){
+        redirectBackendServer(error);
         throw error;
     }
 }
@@ -33,6 +46,7 @@ export const questionTitleDelete = async (questionTitle) => {
     try{
         return await axios.post(requestQuestionTitleBaseUrl+'/delete', questionTitle);
     }catch (error){
+        redirectBackendServer(error);
         throw error;
     }
 }
@@ -41,6 +55,7 @@ export const questionDetailsSave = async (questionDetailsWrapper) => {
     try {
         return await axios.post(requestQuestionDetailsBaseUrl + '/save', questionDetailsWrapper);
     } catch (error) {
+        redirectBackendServer(error);
         throw error;
     }
 }
@@ -50,6 +65,7 @@ export const questionDetailsUpdate = async (questionDetails) => {
     try {
         return await axios.post(requestQuestionDetailsBaseUrl + '/update', questionDetails);
     } catch (error) {
+        redirectBackendServer(error);
         throw error;
     }
 }
@@ -59,6 +75,7 @@ export const questionDetailsEdit = async (questionDetails) => {
         const response = await axios.post(requestQuestionDetailsBaseUrl + '/edit', questionDetails);
         return response.data;
     } catch (error) {
+        redirectBackendServer(error);
         throw error;
     }
 }
@@ -68,6 +85,7 @@ export const questionDetailsGet = async (questionTitle) => {
         const response = await axios.post(requestQuestionDetailsBaseUrl + "/", questionTitle);
         return response.data;
     } catch (error) {
+        redirectBackendServer(error);
         throw error;
     }
 }
@@ -76,6 +94,7 @@ export const questionDetailsDelete = async (details) => {
     try {
         return await axios.post(requestQuestionDetailsBaseUrl + '/delete', details);
     } catch (error) {
+        redirectBackendServer(error);
         throw error;
     }
 }
@@ -85,9 +104,11 @@ export const takeQuizGet = async (questionTitle) => {
         const response = await axios.post(requestTakeQuestionBaseUrl, questionTitle);
         return response.data;
     } catch (error) {
+        redirectBackendServer(error);
         throw error;
     }
 }
+
 
 
 


### PR DESCRIPTION
axios.defaults.withCredentials = true;
をつけることでリクエスト時に jwt_token情報を付与する